### PR TITLE
Allow UpdateProjectRepositoryPathAsync fileName & path to differ

### DIFF
--- a/src/Bitbucket.Net/Core/Projects/BitbucketClient.cs
+++ b/src/Bitbucket.Net/Core/Projects/BitbucketClient.cs
@@ -677,7 +677,7 @@ namespace Bitbucket.Net
                 throw new ArgumentException($"File doesn't exist: {fileName}");
             }
 
-            long fileSize = new FileInfo(path).Length;
+            long fileSize = new FileInfo(fileName).Length;
             var buffer = new byte[fileSize];
             using (var stm = new FileStream(fileName, FileMode.OpenOrCreate, FileAccess.Read))
             {


### PR DESCRIPTION
The current implementation of UpdateProjectRepositoryPathAsync forces the local fileName and repository path to match. 