### PR TITLE
Updated two methods to use PermissionToString

### DIFF
--- a/src/Bitbucket.Net/Core/Projects/BitbucketClient.cs
+++ b/src/Bitbucket.Net/Core/Projects/BitbucketClient.cs
@@ -450,7 +450,7 @@ namespace Bitbucket.Net
         {
             var queryParamValues = new Dictionary<string, object>
             {
-                ["permission"] = permission,
+                ["permission"] = BitbucketHelpers.PermissionToString(permission),
                 ["name"] = name
             };
 
@@ -520,7 +520,7 @@ namespace Bitbucket.Net
         {
             var queryParamValues = new Dictionary<string, object>
             {
-                ["permission"] = permission,
+                ["permission"] = BitbucketHelpers.PermissionToString(permission),
                 ["name"] = name
             };
 


### PR DESCRIPTION
Two methods were using the permission enum instead of PermissionToString